### PR TITLE
introduced themed images, hopefully this approach is a one-off

### DIFF
--- a/src/components/header/NavBar/NavElement.tsx
+++ b/src/components/header/NavBar/NavElement.tsx
@@ -15,13 +15,26 @@ const NavElement = (props: NavElementProps) => {
     let clickable: React.ReactNode = name;
 
     if (icon) {
-        const { path, width, height } = icon;
-        clickable =
-            <Image src={path}
+        // TODO: remove duplicates when theming is fixed
+        // because honestly... this feels beyond janky
+        const { width, height, lightModePath, darkModePath } = icon;
+        clickable = [
+            <Image
+                src={darkModePath}
+                key={`${name}-dark`}
+                className={styles.iconDarkTheme}
                 height={height}
                 width={width}
                 alt={name}
-            />
+            />,
+            <Image
+                src={lightModePath}
+                key={`${name}-light`}
+                className={styles.iconLightTheme}
+                height={height}
+                width={width}
+                alt={name} />
+        ]
     }
 
     return (

--- a/src/components/header/NavBar/NavElementStyles.module.sass
+++ b/src/components/header/NavBar/NavElementStyles.module.sass
@@ -7,4 +7,16 @@
 .noPadding
     padding-left: 0px;
 
+.iconDarkTheme
+    display: none
 
+.iconLightTheme
+    display: none
+
+@media (prefers-color-scheme: dark)
+    .iconLightTheme
+        display: block
+
+@media (prefers-color-scheme: light)
+    .iconDarkTheme
+        display: block

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { HEADER_ELEMENTS } from "./types";
 
 import { isDarkMode } from "@/utilities";
@@ -10,6 +8,7 @@ import lightModeLinkedInIcon from "@/images/linkedInBlack.png";
 
 // TODO: adjust ordering if desired
 
+// TODO: fix band-aid solution for theming
 export const HEADER: HEADER_ELEMENTS = {
     'PROJECTS': {
         'name': 'Projects',
@@ -28,6 +27,8 @@ export const HEADER: HEADER_ELEMENTS = {
         'path': 'https://www.linkedin.com/in/leo-leblanc/',
         'icon': {
             path: isDarkMode() ? darkModeLinkedInIcon : lightModeLinkedInIcon,
+            darkModePath: darkModeLinkedInIcon,
+            lightModePath: darkModeLinkedInIcon,
             height: 18,
             width: 21.17
         }
@@ -37,6 +38,8 @@ export const HEADER: HEADER_ELEMENTS = {
         'path': 'https://github.com/leoleblanc',
         'icon': {
             path: isDarkMode() ? darkModeGitHubIcon : lightModeGitHubIcon,
+            darkModePath: darkModeGitHubIcon,
+            lightModePath: lightModeGitHubIcon,
             height: 18,
             width: 18
         }

--- a/src/global/types.ts
+++ b/src/global/types.ts
@@ -9,6 +9,8 @@ export interface HEADER_ELEMENT {
     path: string;
     icon?: {
         path: StaticImageData,
+        lightModePath: StaticImageData,
+        darkModePath: StaticImageData,
         height: number,
         width: number
     };

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,8 +1,6 @@
-'use client';
-
 export const isDarkMode = () => {
-    // TODO: Fix this so that server and client agree
-    return true;
+    // TODO: Find a way to detect preferences server side
+
     if (typeof window == 'undefined') {
         return true;
     } else {


### PR DESCRIPTION
Adding functionality to detect light or dark and show appropriate image

<img width="869" alt="Screen Shot 2025-06-03 at 7 15 02 PM" src="https://github.com/user-attachments/assets/ff14b299-cd8f-46f5-a5d9-78cc8eb1b767" />
<img width="866" alt="Screen Shot 2025-06-03 at 7 15 23 PM" src="https://github.com/user-attachments/assets/b4721777-4026-4272-bc05-b42c5f75a27b" />

Would like to devise a better way to handle this. I did it this way because there was an HTML mismatch between the server and client when I attempted to read the window (since the server doesn't have access to window).

I guess though, CSS is fine because only the client cares about CSS, and I decided to use the CSS to show or hide the images. Feels very wrong though.
